### PR TITLE
added null checking to loadingContainerState in dismiss method to prevent loading not getting remove

### DIFF
--- a/lib/src/easy_loading.dart
+++ b/lib/src/easy_loading.dart
@@ -256,14 +256,18 @@ class EasyLoading {
     _getInstance()._cancelTimer();
 
     if (animation) {
-      final Completer<void> completer = Completer<void>();
-      _getInstance().key?.currentState?.dismiss(completer);
-      completer.future.then((value) {
-        _getInstance()._remove();
-      });
-    } else {
-      _getInstance()._remove();
+      LoadingContainerState loadingContainerState =
+          _getInstance().key?.currentState;
+      if (loadingContainerState != null) {
+        final Completer<void> completer = Completer<void>();
+        loadingContainerState.dismiss(completer);
+        completer.future.then((value) {
+          _getInstance()._remove();
+        });
+        return;
+      }
     }
+    _getInstance()._remove();
   }
 
   /// show loading


### PR DESCRIPTION
if the below code is called consecutively, the loading container will not be removed due to loadingContainerState is null and the completer future will not be completed.

```
EasyLoading.show();
EasyLoading.dismiss();
```

null checking is added to loadingContainerState in dismiss method to prevent loading not getting remove